### PR TITLE
LatinIME: Remove gesture preference if gesture lib is unavailable

### DIFF
--- a/java/src/com/android/inputmethod/latin/settings/Settings.java
+++ b/java/src/com/android/inputmethod/latin/settings/Settings.java
@@ -49,6 +49,7 @@ public final class Settings implements SharedPreferences.OnSharedPreferenceChang
     public static final String SCREEN_ACCOUNTS = "screen_accounts";
     public static final String SCREEN_THEME = "screen_theme";
     public static final String SCREEN_DEBUG = "screen_debug";
+    public static final String SCREEN_GESTURE = "screen_gesture";
     // In the same order as xml/prefs.xml
     public static final String PREF_AUTO_CAP = "auto_cap";
     public static final String PREF_VIBRATE_ON = "vibrate_on";

--- a/java/src/com/android/inputmethod/latin/settings/SettingsFragment.java
+++ b/java/src/com/android/inputmethod/latin/settings/SettingsFragment.java
@@ -31,6 +31,7 @@ import com.android.inputmethod.latin.R;
 import com.android.inputmethod.latin.define.ProductionFlags;
 import com.android.inputmethod.latin.utils.ApplicationUtils;
 import com.android.inputmethod.latin.utils.FeedbackUtils;
+import com.android.inputmethod.latin.utils.JniUtils;
 import com.android.inputmethodcommon.InputMethodSettingsFragment;
 
 public final class SettingsFragment extends InputMethodSettingsFragment {
@@ -54,6 +55,10 @@ public final class SettingsFragment extends InputMethodSettingsFragment {
         if (!ProductionFlags.ENABLE_ACCOUNT_SIGN_IN) {
             final Preference accountsPreference = findPreference(Settings.SCREEN_ACCOUNTS);
             preferenceScreen.removePreference(accountsPreference);
+        }
+        if (!JniUtils.mHaveGestureLib) {
+            final Preference gesturePreference = findPreference(Settings.SCREEN_GESTURE);
+            preferenceScreen.removePreference(gesturePreference);
         }
     }
 


### PR DESCRIPTION
Gesture typing won't work without the gesture library,
so remove the preference to not mislead users
into thinking that gesture typing is supported.

Change-Id: I387ae83fd174b57fc48fe7bcfc37e3010ce89b12